### PR TITLE
Added support to generate enum types

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -48,7 +48,6 @@ export const getScalar = (item: SchemaObject) => {
   }
 
   const nullable = item.nullable ? " | null" : "";
-
   switch (item.type) {
     case "int32":
     case "int64":
@@ -61,7 +60,6 @@ export const getScalar = (item: SchemaObject) => {
 
     case "boolean":
       return "boolean" + nullable;
-
     case "array":
       return getArray(item) + nullable;
 
@@ -75,12 +73,27 @@ export const getScalar = (item: SchemaObject) => {
     case "dateTime":
     case "date-time":
     case "password":
-      return (item.enum ? `"${item.enum.join(`" | "`)}"` : "string") + nullable;
+      return (item.enum ? getEnum(item.enum) : "string") + nullable;
 
     case "object":
     default:
       return getObject(item) + nullable;
   }
+};
+
+/**
+ * Generates a string enum values
+ * https://www.typescriptlang.org/docs/handbook/enums.html#string-enums
+ *
+ * @param $ref
+ */
+export const getEnum = (enumValues: any[]): string => {
+  return enumValues
+    .reduce((acc, value) => {
+      acc.push(`${value} = '${value}'`);
+      return acc;
+    }, [])
+    .join(",");
 };
 
 /**
@@ -513,6 +526,10 @@ export const generateSchemasDefinition = (schemas: ComponentsObject["schemas"] =
         !isReference(schema) &&
         !schema.nullable
           ? generateInterface(name, schema)
+          : (schema as SchemaObject)?.enum
+          ? `${formatDescription(isReference(schema) ? undefined : schema.description)}export enum ${pascal(
+              name,
+            )} { ${resolveValue(schema)} }`
           : `${formatDescription(isReference(schema) ? undefined : schema.description)}export type ${pascal(
               name,
             )} = ${resolveValue(schema)};`,


### PR DESCRIPTION
# Why

Currently the generator doesn't support enum types. Instead, it's exporting them as a type. This forces the developer to create a enum based on the exported type, when he could have the type already created for him.