### PR TITLE
Fix - Handle unspecified responses without a schema

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -211,7 +211,12 @@ export const getResReqTypes = (
             contentType.startsWith("application/json") ||
             contentType.startsWith("application/octet-stream")
           ) {
-            const schema = res.content[contentType].schema!;
+            const schema = res.content[contentType].schema;
+
+            if (!schema) {
+              return "void";
+            }
+
             return resolveValue(schema);
           }
         }


### PR DESCRIPTION
Heya ;-)

While working on a project one of the OpenAPI specs we received from the backend team contained some pollution they weren't able to resolve. The response models for 200s / errors are OK, but there are some unspecified responses that look like this:

```
"202":{
   "description":"User profile",
   "content":{
      "application/json":{
         
      },
      "text/json":{
         
      }
   }
}
```

this resulted in the generator failing as it would paste a pipe `|` after a 200 response type which isn't quite valid

```
export type SomeResponse = SomeModel | |
```

Instead, there's now one additional check to see if we can output a schema model, if it's not there, we output "void"> Admittedly, this is of course an issue with the spec itself, but I simply don't have control over that part of our codebase 